### PR TITLE
Make script executable (this flag gets removed by Windows)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ dist: bionic
 compiler:
   - gcc
   - clang 
+  - intel
 
 install: 
   # Required on bionic

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,11 +33,11 @@ services:
 script: 
   # Build the project, then:
   - qmake -qt=qt5 DEFINES+=IS_ON_TRAVIS DEFINES+=LOGIC_ONLY simulation_logic_only.pro
-  - make --silent debug
+  - make debug
   - ./simulation_logic_only --test
   # Build and run and profile normal program
   - make clean
-  - make --silent release
+  - make release
   - timeout 150s ./simulation_logic_only 
   - gprof simulation_logic_only > gprof.log
   - head gprof.log -n 300

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,9 +42,11 @@ script:
   - gprof simulation_logic_only > gprof.log
   - head gprof.log -n 300
   # OCLint, failed OCLint does not break the build
+  - chmod +x scripts/do_oclint
   - ./scripts/do_oclint || true
   # Get code coverage
   - cp debug/*.* .
+  - chmod +x scripts/get_code_cov
   - ./scripts/get_code_cov >/dev/null
   - codecov >/dev/null
   # cppcheck

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ install:
   # Codecov
   - sudo pip install codecov
   # OCLint
+  - chmod +x scripts/install_oclint
   - ./scripts/install_oclint
   # clang-tidy
   - sudo apt install -qq clang clang-tidy

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,10 @@ compiler:
   - clang 
   - intel
 
+env:
+  # As per http://docs.travis-ci.com/user/languages/cpp/#OpenMP-projects don't be greedy with OpenMP.
+  - OMP_NUM_THREADS=4
+
 install: 
   # Required on bionic
   - sudo apt update -qq

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ services:
 
 script: 
   # Build the project, then:
-  - qmake -qt=qt5 DEFINES+=IS_ON_TRAVIS DEFINES+=LOGIC_ONLY simulation_logic_only.pro
+  - qmake -qt=qt5 -QMAKE_CXX="$CXX" DEFINES+=IS_ON_TRAVIS DEFINES+=LOGIC_ONLY simulation_logic_only.pro
   - make debug
   - ./simulation_logic_only --test
   # Build and run and profile normal program


### PR DESCRIPTION
Hi @swom,

Here is possibly the fix for 

```
home/travis/.travis/functions: line 109: ./scripts/install_oclint: Permission denied
```

from [this Travis CI log file](https://travis-ci.org/github/swom/project1_vG_W_2016/jobs/729593193#L1166).

It is caused by Windows, which is unaware of Linux file permissions. The fix lets Travis add the file permission to execute (hence the `-x`) bash script.

Cheers, Richel 